### PR TITLE
Added support for our SOAP requests

### DIFF
--- a/lib/ephemeral_response/net_http.rb
+++ b/lib/ephemeral_response/net_http.rb
@@ -23,7 +23,7 @@ module Net
 
     def request(request, body = nil, &block)
       generate_uri(request)
-      EphemeralResponse::Fixture.respond_to(uri, request, block) do
+      EphemeralResponse::Fixture.respond_to(uri, request, body, block) do
         do_start_with_ephemeral_response
         request_without_ephemeral_response(request, body, &block)
       end

--- a/spec/ephemeral_response/net_http_spec.rb
+++ b/spec/ephemeral_response/net_http_spec.rb
@@ -4,6 +4,19 @@ describe Net::HTTP do
   subject { Net::HTTP.new('example.com') }
   let(:request) { Net::HTTP::Get.new("/foo?q=1") }
   let(:uri) { URI.parse("http://example.com/foo?q=1") }
+  let(:body) { <<-XML }
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope
+       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Header>
+      </env:Header>
+      <env:Body>
+        <getClientAccounts xmlns="https://adwords.google.com/api/adwords/v13"></getClientAccounts>
+      </env:Body>
+    </env:Envelope>
+    XML
   let(:response) { OpenStruct.new(:body => "Hello") }
 
   before do
@@ -63,7 +76,7 @@ describe Net::HTTP do
 
     context "fixture exists" do
       before do
-        fixture = EphemeralResponse::Fixture.new(uri, request) do |f|
+        fixture = EphemeralResponse::Fixture.new(uri, request, body) do |f|
           f.response = response
         end
         fixture.register
@@ -75,12 +88,12 @@ describe Net::HTTP do
 
       it "does not connect" do
         subject.should_not_receive(:connect_without_ephemeral_response)
-        subject.request(request)
+        subject.request(request, body)
       end
 
       it "does not call #request_without_ephemeral_response" do
         subject.should_not_receive(:request_without_ephemeral_response).with(request, nil).and_return(response)
-        subject.request(request)
+        subject.request(request, body)
       end
 
       it "yields the response to the block" do

--- a/spec/integration/read_body_compatibility_spec.rb
+++ b/spec/integration/read_body_compatibility_spec.rb
@@ -48,7 +48,7 @@ describe "Read Body Compatibility" do
       post = Net::HTTP::Post.new('/')
       real_response = nil
       http.post('/', 'foo=bar') {|s| real_response = s}
-      fixture = EphemeralResponse::Fixture.find(uri, post)
+      fixture = EphemeralResponse::Fixture.find(uri, post, "foo=bar")
       File.exists?(fixture.path).should be_true
       fixture_response = send_request(post, 'foo=bar').body
       real_response.should == fixture_response

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'rubygems'
 require 'net/https'
 require 'ephemeral_response'
 require 'fakefs/safe'


### PR DESCRIPTION
They weren't being sent out with a body on the request object, choosing instead to be passed in as the second parameter to Net::HTTP#request.
